### PR TITLE
Update Playwright dependencies to 1.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
         "release": "npm publish --access public"
     },
     "dependencies": {
-        "@playwright/test": "^1.52.0"
+        "@playwright/test": "^1.57.0"
     },
     "devDependencies": {
         "@types/node": "22.10.10",
+        "playwright": "^1.57.0",
         "prettier": "3.4.2",
-        "playwright": "^1.52.0",
         "typescript": "5.7.3"
     },
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       '@playwright/test':
-        specifier: ^1.52.0
-        version: 1.52.0
+        specifier: ^1.57.0
+        version: 1.57.0
     devDependencies:
       '@types/node':
         specifier: 22.10.10
         version: 22.10.10
       playwright:
-        specifier: ^1.52.0
-        version: 1.52.0
+        specifier: ^1.57.0
+        version: 1.57.0
       prettier:
         specifier: 3.4.2
         version: 3.4.2
@@ -27,8 +27,8 @@ importers:
 
 packages:
 
-  '@playwright/test@1.52.0':
-    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -40,13 +40,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  playwright-core@1.52.0:
-    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.52.0:
-    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -65,9 +65,9 @@ packages:
 
 snapshots:
 
-  '@playwright/test@1.52.0':
+  '@playwright/test@1.57.0':
     dependencies:
-      playwright: 1.52.0
+      playwright: 1.57.0
 
   '@types/node@22.10.10':
     dependencies:
@@ -76,11 +76,11 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  playwright-core@1.52.0: {}
+  playwright-core@1.57.0: {}
 
-  playwright@1.52.0:
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.52.0
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
### Motivation
- Update `@playwright/test` and `playwright` to resolve a security alert and move the project to Playwright `1.57.0`.

### Description
- Bumped `@playwright/test` and `playwright` to `^1.57.0` in `package.json` and refreshed `pnpm-lock.yaml` to lock the updated Playwright packages.

### Testing
- No automated tests were run for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69686c1a4a108329aa056a044bc6dc87)